### PR TITLE
Added synchronous TryLock/TryEnter methods with Disposable out param.

### DIFF
--- a/src/Nito.AsyncEx.Coordination/AsyncLock.cs
+++ b/src/Nito.AsyncEx.Coordination/AsyncLock.cs
@@ -130,6 +130,29 @@ namespace Nito.AsyncEx
         {
             return Lock(CancellationToken.None);
         }
+        
+        /// <summary>
+        /// Attempts to acquire the lock. Returns true if the current thread acquires the lock; otherwise, false.
+        /// </summary>
+        /// <param name="disposable">The IDisposable if lock is successfully acquired, otherwise null.</param>
+        /// <returns>True if the current thread acquires the lock; otherwise, false.</returns>
+        public bool TryLock(out IDisposable disposable)
+        {
+            lock (_mutex)
+            {
+                if (!_taken)
+                {
+                    // If the lock is available, take it immediately.
+                    _taken = true;
+
+                    disposable = _cachedKeyTask.Result;
+                    return true;
+                }
+                
+                disposable = null;
+                return false;
+            }
+        }
 
         /// <summary>
         /// Releases the lock.

--- a/src/Nito.AsyncEx.Coordination/AsyncMonitor.cs
+++ b/src/Nito.AsyncEx.Coordination/AsyncMonitor.cs
@@ -82,6 +82,14 @@ namespace Nito.AsyncEx
             return Enter(CancellationToken.None);
         }
 
+        /// <summary>		
+        /// Attempts to synchronously enter the monitor. Returns true if the current thread acquires the lock; otherwise, false.
+        /// </summary>
+        public bool TryEnter(out IDisposable disposable)
+        {            
+            return _asyncLock.TryLock(out disposable);
+        }
+
         /// <summary>
         /// Asynchronously waits for a pulse signal on this monitor. The monitor MUST already be entered when calling this method, and it will still be entered when this method returns, even if the method is cancelled. This method internally will leave the monitor while waiting for a notification.
         /// </summary>


### PR DESCRIPTION
This adds similar Monitor.TryEnter functionality to the AsyncMonitor.
